### PR TITLE
[IMP] tier_validation: Instalación de módulos de validaciones de niveles de la OCA

### DIFF
--- a/product_state/__manifest__.py
+++ b/product_state/__manifest__.py
@@ -18,6 +18,7 @@
         "views/product_state_views.xml",
     ],
     "application": False,
+    "auto_install": True, # TRESCLOUD: Util para instalación automática desde el autoinstaller. Módulo: Product Tier Validation (product_tier_validation)
     "maintainers": ["emagdalenaC2i"],
     "post_init_hook": "post_init_hook",
 }

--- a/product_tier_validation/__manifest__.py
+++ b/product_tier_validation/__manifest__.py
@@ -9,6 +9,7 @@
     "author": "Open Source Integrators, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
+    "auto_install": True, # TRESCLOUD: Util para instalación automática desde el autoinstaller
     "maintainers": ["dreispt"],
     "development_status": "Beta",
     "depends": ["product_state", "base_tier_validation"],


### PR DESCRIPTION
- Se añade product_tier_validation para instalar el módulo sale_tier_validation_rules que centraliza las validaciones de niveles de la OCA.

Tarea: #9924